### PR TITLE
feat: Add endpoint to incrementally update base knowledge

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,47 +1,61 @@
 import os
+import shutil
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 
 # Import helper functions from other modules
 from uploader import save_uploaded_file_as_text
+from base_db_manager import add_pdf_to_base_db
 
 # --- FastAPI Router ---
 admin_router = APIRouter()
 
 # --- Constants for data paths ---
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-KNOWLEDGE_PATH = os.path.join(BASE_DIR, "data", "knowledge")
+BASE_DOCS_DIR = os.path.join(BASE_DIR, "data", "base_documents")
 PROMOS_PATH = os.path.join(BASE_DIR, "data", "promos")
 INSTRUCTIONS_PATH = os.path.join(BASE_DIR, "data", "instructions")
 
 
 # --- File Upload Endpoints ---
 
-@admin_router.post("/upload/knowledge", summary="Upload a knowledge base file")
-async def upload_knowledge_file(file: UploadFile = File(...)):
+@admin_router.post("/add-to-knowledge-base", summary="Add a PDF to the foundational knowledge base")
+async def add_to_knowledge_base(file: UploadFile = File(...)):
     """
-    Accepts a .docx or .pdf file and saves its content as a .txt file
-    in the `data/knowledge` directory.
-    
-    NOTE: After uploading, you must manually run 'python create_database.py' 
-    from your terminal to update the bot's knowledge.
+    Accepts a PDF file, saves it to the `data/base_documents` directory,
+    and then incrementally updates the foundational vector store with its content.
+    """
+    if not file.filename.endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Invalid file type. Please upload a .pdf file.")
 
-    - **file**: The .docx or .pdf file to be uploaded.
-    """
-    if not (file.filename.endswith(".docx") or file.filename.endswith(".pdf")):
-        raise HTTPException(status_code=400, detail="Invalid file type. Please upload a .docx or .pdf file.")
-    
     try:
-        saved_path = await save_uploaded_file_as_text(file, KNOWLEDGE_PATH)
-        return JSONResponse(
-            status_code=200,
-            content={
-                "message": "Knowledge file uploaded successfully. Run 'python create_database.py' to re-index.", 
-                "filepath": saved_path
-            }
-        )
+        # Ensure the target directory exists
+        os.makedirs(BASE_DOCS_DIR, exist_ok=True)
+
+        # Define the path to save the uploaded PDF
+        file_path = os.path.join(BASE_DOCS_DIR, file.filename)
+
+        # Save the uploaded file
+        with open(file_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+
+        print(f"Saved new knowledge PDF to: {file_path}")
+
+        # Trigger the incremental update of the vector store
+        success = add_pdf_to_base_db(file_path)
+
+        if success:
+            return JSONResponse(
+                status_code=200,
+                content={"message": "Successfully added document to the knowledge base."}
+            )
+        else:
+            # If add_pdf_to_base_db returns False, it means an internal error occurred
+            raise HTTPException(status_code=500, detail="Failed to process the document and add it to the vector store.")
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to process file: {e}")
+        # Catch any other exceptions during file handling or processing
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}")
 
 
 @admin_router.post("/upload/promo", summary="Upload a promotions file")

--- a/base_db_manager.py
+++ b/base_db_manager.py
@@ -1,0 +1,87 @@
+import os
+from dotenv import load_dotenv
+
+# --- Load environment variables from .env file FIRST ---
+load_dotenv()
+
+from langchain_community.vectorstores import Chroma
+from langchain_openai import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import PyMuPDFLoader
+
+# --- Constants ---
+# Define the path to the foundational database
+BASE_DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vectorstore_base")
+BASE_COLLECTION_NAME = "base_knowledge"
+
+def add_pdf_to_base_db(pdf_path: str):
+    """
+    Processes a single PDF file and adds its content to the existing
+    foundational knowledge base.
+
+    This function performs an incremental update, meaning it does not
+    rebuild the entire database. It loads the new document, splits it
+    into chunks, and adds those chunks to the existing ChromaDB store.
+
+    Args:
+        pdf_path (str): The full path to the PDF file to be added.
+
+    Returns:
+        bool: True if the operation was successful, False otherwise.
+    """
+    if not os.path.exists(pdf_path):
+        print(f"Error: The file '{pdf_path}' was not found.")
+        return False
+
+    if not os.path.exists(BASE_DB_PATH):
+        print(f"Error: The base vector store at '{BASE_DB_PATH}' does not exist. Please build it first using `build_base_db.py`.")
+        return False
+
+    print(f"--- Starting incremental update for: {os.path.basename(pdf_path)} ---")
+
+    try:
+        # 1. Load the new document
+        print(f"Loading document: {pdf_path}")
+        loader = PyMuPDFLoader(pdf_path)
+        documents = loader.load()
+        if not documents:
+            print("Warning: The PDF document appears to be empty or could not be loaded.")
+            return False
+
+        # 2. Split the document into chunks
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+        chunks = text_splitter.split_documents(documents)
+        print(f"Split document into {len(chunks)} chunks.")
+
+        if not chunks:
+            print("No text chunks to add to the database.")
+            return False
+
+        # 3. Initialize the embedding function
+        embedding_function = OpenAIEmbeddings(
+            model="text-embedding-ada-002",
+            max_retries=6,
+            chunk_size=500
+        )
+
+        # 4. Load the existing vector store
+        print(f"Loading existing vector store from: {BASE_DB_PATH}")
+        vector_store = Chroma(
+            persist_directory=BASE_DB_PATH,
+            embedding_function=embedding_function,
+            collection_name=BASE_COLLECTION_NAME
+        )
+
+        # 5. Add the new document chunks to the vector store
+        print(f"Adding {len(chunks)} new chunks to the vector store...")
+        vector_store.add_documents(chunks)
+
+        # Note: ChromaDB with a persistent client auto-saves changes.
+        # There is no explicit .save() method needed.
+
+        print("✅ Incremental update complete. The new document has been added to the knowledge base.")
+        return True
+
+    except Exception as e:
+        print(f"An error occurred during the incremental update: {e}")
+        return False


### PR DESCRIPTION
This commit introduces a new feature that allows an administrator to add new PDF documents to the foundational knowledge base via an API endpoint.

Key changes:
- A new module, `base_db_manager.py`, is created to handle the logic of performing incremental updates on the ChromaDB vector store. This avoids the need to rebuild the entire database for each new document.
- A new endpoint, `/admin/add-to-knowledge-base`, is added to `admin.py`. This endpoint accepts a PDF file, saves it to the `data/base_documents` directory for record-keeping, and then calls the new incremental update function.
- The old `/upload/knowledge` endpoint, which required a manual rebuild step, has been removed.